### PR TITLE
Revert "fix(dependencies): update dependency string-width to v6"

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-helmet": "6.1.0",
-        "string-width": "6.1.0",
+        "string-width": "5.1.2",
         "typestyle": "2.4.0",
         "use-is-in-viewport": "1.0.9"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-    "extends": ["@whtsky"]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,15 @@
+{
+    extends: ['@whtsky'],
+    packageRules: [
+        {
+            /**
+             * string-width@6 is not compatible with all Firefox versions
+             * issue: https://github.com/sindresorhus/string-width/issues/50#issue-1722323414
+             * root cause: https://github.com/sindresorhus/string-width/pull/47
+             * TODO: add basic E2E test (ﾟ∀。)
+             */
+            matchPackageNames: ['string-width'],
+            enabled: false,
+        },
+    ],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4791,11 +4791,6 @@ emissary@^1:
     property-accessors "^1.1"
     underscore-plus "1.x"
 
-emoji-regex@^10.2.1:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.2.1.tgz#a41c330d957191efd3d9dfe6e1e8e1e9ab048b3f"
-  integrity sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -11099,13 +11094,13 @@ string-similarity@^1.2.2:
     lodash.map "^4.6.0"
     lodash.maxby "^4.6.0"
 
-string-width@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-6.1.0.tgz#96488d6ed23f9ad5d82d13522af9e4c4c3fd7518"
-  integrity sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==
+string-width@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
   dependencies:
     eastasianwidth "^0.2.0"
-    emoji-regex "^10.2.1"
+    emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
 string-width@^1.0.1:


### PR DESCRIPTION
This reverts commit 39f56ba.

string-width@6 uses `Intl.Segment` while no Firefox version has implemented

- sindresorhus/string-width#47
- sindresorhus/string-width#50 (comment)