### PR TITLE
chore(build): use Playwright container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,10 @@ jobs:
     e2e:
         runs-on: ubuntu-latest
         needs: build
+        container:
+            image: mcr.microsoft.com/playwright:v1.40.0-jammy
         steps:
-            - uses: nschloe/action-cached-lfs-checkout@v1
+            - uses: actions/checkout@v4
 
             - name: Prepare Node.js and Yarn
               uses: ./.github/actions/setup-node-yarn
@@ -59,11 +61,12 @@ jobs:
                   cache: true
 
             - run: yarn install
-            - run: yarn playwright install --with-deps
+
             - name: Run Playwright tests
               env:
                   RESTIA_E2E_URL: ${{ needs.build.outputs.deploy-url }}
               run: yarn playwright test
+
             - uses: actions/upload-artifact@v3
               if: always()
               with:


### PR DESCRIPTION
To get rid of `playwright install --with-deps`

Memo:

`mcr.microsoft.com/playwright:v1.40.0-jammy` lacks some essential dependencies:

- `git-lfs` (optional): https://github.com/frantic1048/Restia/actions/runs/7102858807/job/19334299307#step:3:431
- `make`(possibly more devtools are missing): https://github.com/frantic1048/Restia/actions/runs/7102931756/job/19334521548#step:5:91